### PR TITLE
Include `wp-cache-phase1.php` before calling `wp_cache_clean_cache()`.

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -31,6 +31,7 @@ class WPSuperCache_Command extends WP_CLI_Command {
 		} else {
 			global $file_prefix;
 
+			require_once( WPCACHEHOME . '/wp-cache-phase1.php' );
 			wp_cache_clean_cache( $file_prefix, true );
 
 			WP_CLI::success( 'Cache cleared.' );


### PR DESCRIPTION
`wp_cache_clean_cache()` will sometimes call `wp_cache_debug()`, which was not previously being loaded. That resulted in a fatal PHP error because the function was undefined.

WP Super Cache added the call to `wp_cache_debug()` in https://plugins.trac.wordpress.org/changeset/1005138