### PR TITLE
Fixes discrepancy between commands ena/dis and status

### DIFF
--- a/src/WP_Super_Cache_Command.php
+++ b/src/WP_Super_Cache_Command.php
@@ -115,12 +115,20 @@ class WP_Super_Cache_Command extends WP_CLI_Command {
 	 * @when after_wp_load
 	 */
 	public function enable( $args = array(), $assoc_args = array() ) {
-		global $super_cache_enabled;
+		global $cache_enabled, $wp_cache_mod_rewrite;
 
 		$this->load();
-		wp_super_cache_enable();
 
-		if ( $super_cache_enabled ) {
+		wp_cache_enable();
+		if ( ! defined( 'DISABLE_SUPERCACHE' ) ) {
+			wp_super_cache_enable();
+		}
+
+		if ( $wp_cache_mod_rewrite ) {
+			add_mod_rewrite_rules();
+		}
+
+		if ( $cache_enabled ) {
 			WP_CLI::success( 'The WP Super Cache is enabled.' );
 		} else {
 			WP_CLI::error( 'The WP Super Cache is not enabled, check its settings page for more info.' );
@@ -133,9 +141,11 @@ class WP_Super_Cache_Command extends WP_CLI_Command {
 	 * @when after_wp_load
 	 */
 	public function disable( $args = array(), $assoc_args = array() ) {
-		global $super_cache_enabled;
+		global $cache_enabled;
 
 		$this->load();
+
+		wp_cache_disable();
 		wp_super_cache_disable();
 
 		if ( ! $super_cache_enabled ) {

--- a/src/WP_Super_Cache_Command.php
+++ b/src/WP_Super_Cache_Command.php
@@ -148,7 +148,7 @@ class WP_Super_Cache_Command extends WP_CLI_Command {
 		wp_cache_disable();
 		wp_super_cache_disable();
 
-		if ( ! $super_cache_enabled ) {
+		if ( ! $cache_enabled ) {
 			WP_CLI::success( 'The WP Super Cache is disabled.' );
 		} else {
 			WP_CLI::error( 'The WP Super Cache is still enabled, check its settings page for more info.' );


### PR DESCRIPTION
* Disable/enables both methods (wp-cache/super-cache).
* Updates rewrite rules based on previous setting in `wp-cache-config.php`.

This PR and #24 should synchronize commands enable, disable, status with same options on WPSC dashboard.
